### PR TITLE
Fix Connect and Watch iterator

### DIFF
--- a/aetcd/client.py
+++ b/aetcd/client.py
@@ -273,7 +273,7 @@ class Client:
 
     @_handle_errors
     @_ensure_connected
-    async def reset_auth_token(self)
+    async def reset_auth_token(self) -> None:
         cred_params = [c is not None for c in (self._username, self._password)]
         if all(cred_params):
             auth_request = rpc.AuthenticateRequest(

--- a/aetcd/client.py
+++ b/aetcd/client.py
@@ -273,6 +273,20 @@ class Client:
 
     @_handle_errors
     @_ensure_connected
+    async def reset_auth_token(self)
+        cred_params = [c is not None for c in (self._username, self._password)]
+        if all(cred_params):
+            auth_request = rpc.AuthenticateRequest(
+                name=self._username,
+                password=self._password,
+            )
+            resp = await self.auth_stub.Authenticate(auth_request, timeout=self._timeout)
+            metadata = (('token', resp.token),)
+            self.metadata = metadata
+            self._watcher._metadata = metadata
+
+    @_handle_errors
+    @_ensure_connected
     async def get(
         self,
         key: bytes,

--- a/aetcd/exceptions.py
+++ b/aetcd/exceptions.py
@@ -21,6 +21,10 @@ class InvalidArgumentError(ClientError):
     """Raises on errors associated with incorrect arguments being provided."""
 
 
+class UnauthenticatedError(ClientError):
+    """Raises on etcd unauthenticated errors."""
+
+
 class PreconditionFailedError(ClientError):
     """Raises on etcd server precondition errors."""
 
@@ -52,6 +56,7 @@ _EXCEPTIONS_BY_CODE = {
     rpc.StatusCode.INTERNAL: InternalError,
     rpc.StatusCode.INVALID_ARGUMENT: InvalidArgumentError,
     rpc.StatusCode.UNAVAILABLE: ConnectionFailedError,
+    rpc.StatusCode.UNAUTHENTICATED: UnauthenticatedError,
 }
 
 

--- a/aetcd/rtypes.py
+++ b/aetcd/rtypes.py
@@ -9,10 +9,11 @@ class _Slotted:
     __slots__ = []
 
     def __repr__(self):
-        return f'{self.__class__.__name__}[' + ', '.join(
-            f'{attr}={getattr(self, attr)}'
-            for attr in self.__slots__
-        ) + ']'
+        return (
+            f'{self.__class__.__name__}['
+            + ', '.join(f'{attr}={getattr(self, attr)}' for attr in self.__slots__)
+            + ']'
+        )
 
 
 class ResponseHeader(_Slotted):
@@ -227,10 +228,7 @@ class DeleteRange:
         return KeyValue(self.prev_kvs[index])
 
     def __repr__(self):
-        return (
-            f'{self.__class__.__name__}'
-            f'[header={self.header!r}, deleted={self.deleted!r}]'
-        )
+        return f'{self.__class__.__name__}' f'[header={self.header!r}, deleted={self.deleted!r}]'
 
 
 class EventKind(str, enum.Enum):
@@ -254,8 +252,7 @@ class Event(_Slotted):
         #: The kind of event. If the type is a ``PUT``, it indicates
         #: new data has been stored to the key. If the type is a ``DELETE``,
         #: it indicates the key was deleted.
-        self.kind: EventKind = rpc.Event.EventType.DESCRIPTOR.values_by_number[
-            kind].name
+        self.kind: EventKind = rpc.Event.EventType.DESCRIPTOR.values_by_number[kind].name
 
         #: Holds the key-value for the event.
         #: A ``PUT`` event contains current key-value pair.
@@ -294,9 +291,8 @@ class Watch:
         #: The ID of the watcher that emits the events.
         self.watch_id: int = watch_id
 
-    async def __aiter__(self):
-        async for event in self._iterator():
-            yield event
+    def __aiter__(self):
+        return self._iterator()
 
     async def cancel(self):
         """Cancel the watcher so that no more events are emitted."""


### PR DESCRIPTION
* Fix the case that connect() is called from multiple tasks.
      What is the problem:
         Supposed that there are more than two tasks running their etcd operations.
         One task calls connect() and await self.auth_stub.Authenticate()
         and meanwhile another task calls connect().
         At that time, self.channel is set but its all stubs are None. So the another task fails

* Fix rtypes.py::Watch.__aiter__() to return proper aiter